### PR TITLE
Add template .phpci.yml file

### DIFF
--- a/.phpci.yml
+++ b/.phpci.yml
@@ -1,0 +1,42 @@
+build_settings:
+    clone_depth: 1 # depth of 1 is a shallow clone, remove this line to clone entire repo
+    ignore:
+        - "vendor"
+        - "Tests"
+    mysql:
+        host: "localhost"
+        user: "root"
+        pass: ""
+
+setup:
+    mysql:
+        - "DROP DATABASE IF EXISTS test;"
+        - "CREATE DATABASE test;"
+        - "GRANT ALL PRIVILEGES ON test.* TO test@'localhost' IDENTIFIED BY 'test';"
+    composer:
+        action: "install"
+
+test:
+    php_unit:
+        config:
+            - "PHPUnit-all.xml"
+            - "PHPUnit-ubuntu-fix.xml"
+        directory:
+            - "tests/"
+        run_from: "phpunit/"
+        coverage: "tests/logs/coverage"
+    php_mess_detector:
+        allow_failures: true
+    php_code_sniffer:
+        standard: "PSR2"
+    php_cpd:
+        allow_failures: true
+    grunt:
+        task: "build"
+
+complete:
+    mysql:
+        host: "localhost"
+        user: "root"
+        pass: ""
+        - "DROP DATABASE IF EXISTS test;"

--- a/.phpci.yml
+++ b/.phpci.yml
@@ -3,16 +3,8 @@ build_settings:
     ignore:
         - "vendor"
         - "Tests"
-    mysql:
-        host: "localhost"
-        user: "root"
-        pass: ""
 
 setup:
-    mysql:
-        - "DROP DATABASE IF EXISTS test;"
-        - "CREATE DATABASE test;"
-        - "GRANT ALL PRIVILEGES ON test.* TO test@'localhost' IDENTIFIED BY 'test';"
     composer:
         action: "install"
 
@@ -22,9 +14,9 @@ test:
             - "PHPUnit-all.xml"
             - "PHPUnit-ubuntu-fix.xml"
         directory:
-            - "tests/"
+            - "Tests/"
         run_from: "phpunit/"
-        coverage: "tests/logs/coverage"
+        coverage: "Tests/logs/coverage"
     php_mess_detector:
         allow_failures: true
     php_code_sniffer:
@@ -33,10 +25,3 @@ test:
         allow_failures: true
     grunt:
         task: "build"
-
-complete:
-    mysql:
-        host: "localhost"
-        user: "root"
-        pass: ""
-        - "DROP DATABASE IF EXISTS test;"


### PR DESCRIPTION
As per [the docs](https://docs.phptesting.org/en/latest/adding-phpci-support-to-your-projects/), we need to add a `.phpci.yml` file to our project's root to enable continuous integration. I took this template file from the docs but changed line 5 from "tests" to "Tests" to match our directory naming. Even if this build script fails, it should allow me to get passed the _Pending_ status in [our PHPCI dashboard](https://tps-dev-ci.ckxu.com/) and view any errors. 